### PR TITLE
feat(jq): Add jq functions for handling Kafka headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,25 @@ As it can be annoying to work with long commands, you may wish to add an alias l
 ```bash
 alias kcat='docker run --rm --network=host edenhill/kcat:1.7.1'
 ```
+
+## jq functions
+
+There are `jq` functions defined in `kafka.jq`.
+These can be imported into a `jq` script using `include "./kafka";` at the start, assuming you are running from the root of this repository.
+
+### Timestamp conversion
+
+One of the `jq` functions is `ts_to_date`, which converts Kafka timestamps, given as milliseconds since the Unix epoch, into human-readable dates.
+Millisecond precision is retained.
+
+Example:
+```bash
+docker run --rm --network=host edenhill/kcat:1.7.1 -b localhost:9092 -t test -CeqJ \
+  | jq 'include "./kafka"; [.ts, ts_to_date]'
+```
+```json
+[
+  1737461938187,
+  "2025-01-21T12:18:58.187Z"
+]
+```

--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ You should see something like:
 ```json
 {"topic":"test","partition":0,"offset":1,"tstype":"create","ts":1737461938187,"broker":1,"key":null,"payload":"data"}
 ```
+
+### Alias
+
+As it can be annoying to work with long commands, you may wish to add an alias like the below to your `~/.bashrc` or equivalent:
+```bash
+alias kcat='docker run --rm --network=host edenhill/kcat:1.7.1'
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # kafka-tools
-A collection of miscellaneous tools for making it easier to work with (Apache) Kafka
+
+A collection of miscellaneous tools for making it easier to work with (Apache) Kafka.
+
+## Running Kafka locally
+
+There are [official instructions](https://kafka.apache.org/quickstart) for running Apache Kafka in different modes (KRaft in Docker, ZooKeeper in Docker, etc.).
+The KRaft in Docker setup can be run with:
+```sh
+KAFKA_VERSION=3.9.0
+docker pull apache/kafka:${KAFKA_VERSION}
+docker run -p 9092 apache/kafka:${KAFKA_VERSION}
+```
+
+## kcat (formerly kafkacat)
+
+`kcat` is available as a Docker image, if you do not have it already installed locally.
+The 1.7.1 [edenhill/kcat image](https://hub.docker.com/r/edenhill/kcat/tags) is under 17MB (compressed).
+
+```sh
+KCAT_VERSION=1.7.1
+docker pull edenhill/kcat:${KCAT_VERSION}
+docker run --network=host --rm edenhill/kcat:${KCAT_VERSION} -b localhost:9092 -L
+```
+
+You should see something like:
+```
+Metadata for all topics (from broker 1: localhost:9092/1):
+ 1 brokers:
+  broker 1 at localhost:9092 (controller)
+ 0 topics:
+```
+
+You can then create some dummy messages and confirm they have been written using:
+```sh
+echo 'data' | docker run --rm -i --network=host edenhill/kcat:1.7.1 -b localhost:9092 -t test -K: -P
+docker run --rm -it --network=host edenhill/kcat:1.7.1 -b localhost:9092 -t test -CeJq
+```
+
+That `-CeqJ` at the end means:
+* run in consumer mode,
+* read messages until the end of the topic then stop,
+* output messages in JSON format, so we can see the headers as well as the message bodies,
+* and do not output informational logs, as this would be annoying for use with `jq`.
+
+You should see something like:
+```json
+{"topic":"test","partition":0,"offset":1,"tstype":"create","ts":1737461938187,"broker":1,"key":null,"payload":"data"}
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A collection of miscellaneous tools for making it easier to work with (Apache) Kafka.
 
-## Running Kafka locally
+## Quickstart
+
+### Running Kafka locally
 
 There are [official instructions](https://kafka.apache.org/quickstart) for running Apache Kafka in different modes (KRaft in Docker, ZooKeeper in Docker, etc.).
 The KRaft in Docker setup can be run with:
@@ -12,7 +14,7 @@ docker pull apache/kafka:${KAFKA_VERSION}
 docker run -p 9092 apache/kafka:${KAFKA_VERSION}
 ```
 
-## kcat (formerly kafkacat)
+### kcat (formerly kafkacat)
 
 `kcat` is available as a Docker image, if you do not have it already installed locally.
 The 1.7.1 [edenhill/kcat image](https://hub.docker.com/r/edenhill/kcat/tags) is under 17MB (compressed).
@@ -47,8 +49,6 @@ You should see something like:
 ```json
 {"topic":"test","partition":0,"offset":1,"tstype":"create","ts":1737461938187,"broker":1,"key":null,"payload":"data"}
 ```
-
-### Alias
 
 As it can be annoying to work with long commands, you may wish to add an alias like the below to your `~/.bashrc` or equivalent:
 ```bash

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Kafka headers are given as a flat list, whereas we typically think of them as ke
 Note that the above message has a _repeated_ header key, `foo`, which is valid usage.
 
 This repository defines another `jq` function, called `headers`, which performs this transformation from list to map, accounting for repeated keys.
+As a further benefit, it does not reorder repeated keys, so any significance of a specific ordering of values will be retained.
 Example:
 ```bash
 kcat -b localhost:9092 -t test -CeqJ \

--- a/kafka.jq
+++ b/kafka.jq
@@ -5,3 +5,15 @@ module {
 
 def ts_to_date:
   .ts | (. % 1000) as $ms | . / 1000 | todate | sub("Z"; ($ms | tostring | "." + . + "Z"));
+
+def headers:
+  .headers
+    | [[range(length)], .]                        # For-each indexed
+    | transpose                                   # Zip indices & headers
+    | [                                           # Split headers into keys & values, drop indices
+        [.[] | select(.[0] % 2 == 0) | .[1]],
+        [.[] | select(.[0] % 2 == 1) | .[1]]
+      ]
+    | transpose                                   # Zip keys & values
+    | reduce .[] as [$k, $v] ({}; .[$k] += [$v])  # Coalesce, accounting for repeated keys
+  ;

--- a/kafka.jq
+++ b/kafka.jq
@@ -4,7 +4,12 @@ module {
 };
 
 def ts_to_date:
-  .ts | (. % 1000) as $ms | . / 1000 | todate | sub("Z"; ($ms | tostring | "." + . + "Z"));
+  .ts
+    | (. % 1000) as $ms
+    | . / 1000
+    | todate
+    | sub("Z"; ($ms | tostring | "." + . + "Z"))
+  ;
 
 def headers:
   .headers

--- a/kafka.jq
+++ b/kafka.jq
@@ -1,0 +1,7 @@
+module {
+  "name": "kafka",
+  "author": "agrski"
+};
+
+def ts_to_date:
+  .ts | (. % 1000) as $ms | . / 1000 | todate | sub("Z"; ($ms | tostring | "." + . + "Z"));


### PR DESCRIPTION
# Why
While tools like `kcat` (formerly `kafkacat`) have a lot of utility, some of the outputs are still awkward to work with, particularly the headers.  These `jq` functions aim to ameliorate that annoyance.

# What
Add `jq` module with functions for:
* Converting timestamps to human-readable date-times.
* Convert headers from a flat list to an object/map/dict.